### PR TITLE
Fix area input handling and power button actions

### DIFF
--- a/S2.html
+++ b/S2.html
@@ -397,11 +397,11 @@
                                     <div class="wpb_wrapper">
                                         <!-- Container per i tasti di selezione potenza -->
                                         <div id="buttonsContainer" class="buttonsContainer">
-                                            <button type="button" id="btn1" class="button-common" onclick="handlePowerButton('btn1', 3.32)">3,32 kWp</button>
-                                            <button type="button" id="btn2" class="button-common" onclick="handlePowerButton('btn2', 4.15)">4,15 kWp</button>
-                                            <button type="button" id="btn3" class="button-common" onclick="handlePowerButton('btn3', 4.98)">4,98 kWp</button>
-                                            <button type="button" id="btn4" class="button-common" onclick="handlePowerButton('btn4', 6.23)">6,23 kWp</button>
-                                            <button type="button" id="btn5" class="button-common" onclick="handlePowerButton('btn5', 8.30)">8,30 kWp</button>
+                                            <button type="button" id="btn1" class="button-common" data-value="3.32" onclick="handlePowerButton(this)">3,32 kWp</button>
+                                            <button type="button" id="btn2" class="button-common" data-value="4.15" onclick="handlePowerButton(this)">4,15 kWp</button>
+                                            <button type="button" id="btn3" class="button-common" data-value="4.98" onclick="handlePowerButton(this)">4,98 kWp</button>
+                                            <button type="button" id="btn4" class="button-common" data-value="6.23" onclick="handlePowerButton(this)">6,23 kWp</button>
+                                            <button type="button" id="btn5" class="button-common" data-value="8.30" onclick="handlePowerButton(this)">8,30 kWp</button>
                                             <button type="button" id="btnOpt" class="button-common">
                                                 Ottimizzatori di potenza 
                                                 <span class="question-button">?<span class="tooltip">Gli <b>ottimizzatori di potenza</b> massimizzano la resa di ogni pannello fotovoltaico, riducendo le perdite causate da ombreggiamenti o differenze di produzione.</span></span>

--- a/S2.js
+++ b/S2.js
@@ -557,14 +557,26 @@ if (step2NextBtn && currentArea >= 16) {
 function updateAreaValue(newValue) {
     // Ensure we don't go below 0
     currentArea = Math.max(0, newValue);
-    
+
     // Update display and localStorage
     if (areaValue) areaValue.textContent = currentArea;
     localStorage.setItem('area', currentArea.toString());
-    
+
     // Show/hide proceed button based on value
     if (step2NextBtn) {
         step2NextBtn.style.display = currentArea >= 16 ? 'block' : 'none';
+    }
+}
+
+// Ensure area value from inline input is saved before leaving Step 2
+function finalizeAreaInput() {
+    const span = document.getElementById('step-box-area-value');
+    if (!span) return;
+    const input = span.querySelector('input');
+    if (input) {
+        const newValue = parseInt(input.value) || 0;
+        span.textContent = newValue;
+        updateAreaValue(newValue);
     }
 }
 
@@ -1151,7 +1163,10 @@ document.addEventListener('DOMContentLoaded', function() {
     
     if (redoBtn) redoBtn.addEventListener('click', redrawPolygon);
     if (step1NextBtn) step1NextBtn.addEventListener('click', goToStep2);
-    if (step2NextBtn) step2NextBtn.addEventListener('click', goToStep3);
+    if (step2NextBtn) step2NextBtn.addEventListener('click', function() {
+        finalizeAreaInput();
+        goToStep3();
+    });
     if (step3NextBtn) step3NextBtn.addEventListener('click', goToStep4);
     if (step4NextButton) {
         step4NextButton.addEventListener('click', function() {


### PR DESCRIPTION
## Summary
- ensure manual area entry is persisted before leaving step 2
- allow power buttons to work by using dataset values and `handlePowerButton(this)`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68625d28f04c832bbeefcf6e0069880c