### PR TITLE
Fix manual area input and spinner overlay

### DIFF
--- a/salientHeadJS
+++ b/salientHeadJS
@@ -571,74 +571,17 @@
         }
     });
 
-    const decreaseAreaBtn = document.getElementById('decreaseArea');
-    const increaseAreaBtn = document.getElementById('increaseArea');
-    const areaValue = document.getElementById('step-box-area-value');
-    const step2NextBtn = document.getElementById('step2Next');
-
     // Helper to update either textContent or value depending on element type
     function displayAreaValue(val) {
-        if (!areaValue) return;
-        if ("value" in areaValue) {
-            areaValue.value = val;
+        const areaEl = document.getElementById('step-box-area-value');
+        if (!areaEl) return;
+        if ("value" in areaEl) {
+            areaEl.value = val;
         } else {
-            areaValue.textContent = val;
+            areaEl.textContent = val;
         }
     }
 
-    // Initialize with stored area value or default to 0
-    let currentArea = parseInt(localStorage.getItem('area') || '0');
-    displayAreaValue(currentArea);
-
-    // Check if the proceed button should be visible on load
-    if (step2NextBtn && currentArea >= 16) {
-        step2NextBtn.style.display = 'block';
-    } else if (step2NextBtn) {
-        step2NextBtn.style.display = 'none';
-    }
-
-    // Update function to keep code DRY
-    function updateAreaValue(newValue) {
-        // Ensure we don't go below 0
-        currentArea = Math.max(0, newValue);
-
-        // Update display and localStorage
-        displayAreaValue(currentArea);
-        localStorage.setItem('area', currentArea.toString());
-
-        // Show/hide proceed button based on value
-        if (step2NextBtn) {
-            step2NextBtn.style.display = currentArea >= 16 ? 'block' : 'none';
-        }
-    }
-
-    // Decrease area button
-    if (decreaseAreaBtn) {
-        decreaseAreaBtn.addEventListener('click', function () {
-            updateAreaValue(currentArea - 1);
-        });
-    }
-
-    // Increase area button
-    if (increaseAreaBtn) {
-        increaseAreaBtn.addEventListener('click', function () {
-            updateAreaValue(currentArea + 1);
-        });
-    }
-
-    // Allow manual editing of the area value if the element is editable or an input
-    if (areaValue) {
-        // Make the element editable in case it's a plain span
-        if (!areaValue.value) {
-            areaValue.setAttribute('contenteditable', 'true');
-        }
-        areaValue.addEventListener('input', function () {
-            const value = parseInt(areaValue.value || areaValue.textContent || '0');
-            if (!isNaN(value)) {
-                updateAreaValue(value);
-            }
-        });
-    }
 
     // Add tracking variables to know if user has made selections
     let userSelectedConsumo = false;
@@ -1218,6 +1161,45 @@
         const addressElement = document.getElementById('selected-address');
         if (addressElement && localStorage.getItem('address')) {
             addressElement.textContent = localStorage.getItem('address');
+        }
+
+        // Setup manual area controls now that DOM is ready
+        const decreaseAreaBtn = document.getElementById('decreaseArea');
+        const increaseAreaBtn = document.getElementById('increaseArea');
+        const areaValue = document.getElementById('step-box-area-value');
+        let currentArea = parseInt(localStorage.getItem('area') || '0');
+        displayAreaValue(currentArea);
+        if (step2NextBtn) {
+            step2NextBtn.style.display = currentArea >= 16 ? 'block' : 'none';
+        }
+
+        function updateAreaValue(newValue) {
+            currentArea = Math.max(0, newValue);
+            displayAreaValue(currentArea);
+            localStorage.setItem('area', currentArea.toString());
+            if (step2NextBtn) {
+                step2NextBtn.style.display = currentArea >= 16 ? 'block' : 'none';
+            }
+        }
+
+        if (decreaseAreaBtn) {
+            decreaseAreaBtn.addEventListener('click', () => updateAreaValue(currentArea - 1));
+        }
+
+        if (increaseAreaBtn) {
+            increaseAreaBtn.addEventListener('click', () => updateAreaValue(currentArea + 1));
+        }
+
+        if (areaValue) {
+            if (!areaValue.value) {
+                areaValue.setAttribute('contenteditable', 'true');
+            }
+            areaValue.addEventListener('input', () => {
+                const value = parseInt(areaValue.value || areaValue.textContent || '0');
+                if (!isNaN(value)) {
+                    updateAreaValue(value);
+                }
+            });
         }
 
         // Add click event for Sistema di Backup button

--- a/salientHeadJS
+++ b/salientHeadJS
@@ -576,9 +576,19 @@
     const areaValue = document.getElementById('step-box-area-value');
     const step2NextBtn = document.getElementById('step2Next');
 
+    // Helper to update either textContent or value depending on element type
+    function displayAreaValue(val) {
+        if (!areaValue) return;
+        if ("value" in areaValue) {
+            areaValue.value = val;
+        } else {
+            areaValue.textContent = val;
+        }
+    }
+
     // Initialize with stored area value or default to 0
     let currentArea = parseInt(localStorage.getItem('area') || '0');
-    if (areaValue) areaValue.textContent = currentArea;
+    displayAreaValue(currentArea);
 
     // Check if the proceed button should be visible on load
     if (step2NextBtn && currentArea >= 16) {
@@ -593,7 +603,7 @@
         currentArea = Math.max(0, newValue);
 
         // Update display and localStorage
-        if (areaValue) areaValue.textContent = currentArea;
+        displayAreaValue(currentArea);
         localStorage.setItem('area', currentArea.toString());
 
         // Show/hide proceed button based on value
@@ -613,6 +623,20 @@
     if (increaseAreaBtn) {
         increaseAreaBtn.addEventListener('click', function () {
             updateAreaValue(currentArea + 1);
+        });
+    }
+
+    // Allow manual editing of the area value if the element is editable or an input
+    if (areaValue) {
+        // Make the element editable in case it's a plain span
+        if (!areaValue.value) {
+            areaValue.setAttribute('contenteditable', 'true');
+        }
+        areaValue.addEventListener('input', function () {
+            const value = parseInt(areaValue.value || areaValue.textContent || '0');
+            if (!isNaN(value)) {
+                updateAreaValue(value);
+            }
         });
     }
 
@@ -742,9 +766,7 @@
 
         // Update all area displays
         document.getElementById('areaValue').textContent = areaInSquareMeters;
-        if (document.getElementById('step-box-area-value')) {
-            document.getElementById('step-box-area-value').textContent = areaInSquareMeters;
-        }
+        displayAreaValue(areaInSquareMeters);
 
         // Store in localStorage
         localStorage.setItem("area", areaInSquareMeters);
@@ -807,9 +829,7 @@
         document.getElementById('area').style.display = 'none';
 
         // Reset area value if the element exists
-        if (document.getElementById('step-box-area-value')) {
-            document.getElementById('step-box-area-value').textContent = '0';
-        }
+        displayAreaValue(0);
     }
 
     // Replace the broken goToStep2 function with this corrected version
@@ -1468,11 +1488,12 @@
         const spinnerOverlay = document.getElementById('calculationSpinnerOverlay') || createCalculationSpinner();
         spinnerOverlay.style.display = 'flex';
 
-        updateEfficiencyOptionsFromDOM();
+        try {
+            updateEfficiencyOptionsFromDOM();
 
 
-        // Save all Step 3 variables
-        saveStep3Variables();
+            // Save all Step 3 variables
+            saveStep3Variables();
 
 
         // Check current values directly instead of just localStorage
@@ -1599,10 +1620,11 @@
             }
         });
 
-        // Hide spinner// Hide spinner and show Step 4 after all calculations are complete
-        spinnerOverlay.style.display = 'none';
-        document.getElementById('section-step4').style.display = 'block';
-
+        } catch (error) {
+            console.error('Error during Step 4 calculations:', error);
+        } finally {
+            spinnerOverlay.style.display = 'none';
+        }
 
         // Proceed to Step 4
         document.getElementById('section-step3').style.display = 'none';
@@ -1660,7 +1682,7 @@
         spinnerOverlay.appendChild(spinner);
         spinnerOverlay.appendChild(message);
         document.body.appendChild(spinnerOverlay);
-
+        spinnerOverlay.style.display = 'none';
         return spinnerOverlay;
     }
 


### PR DESCRIPTION
## Summary
- restore displayAreaValue helper for editable area field
- update area calculations to use displayAreaValue
- hide spinner overlay when created

## Testing
- `node --version`
- `node -c salientHeadJS` *(fails: Unexpected token '<')*

------
https://chatgpt.com/codex/tasks/task_e_6865033f8408832b9152c357b11dc752